### PR TITLE
Update mimuz-ch55x.c

### DIFF
--- a/src/mimuz-ch55x.c
+++ b/src/mimuz-ch55x.c
@@ -121,7 +121,7 @@ void USBSerial_flush(void){
   }
 }
 
-uint8_t USBSerial_write(char c){
+uint8_t USBSerial_write(__data char c){
   uint16_t waitWriteCount;
   if(controlLineState > 0){
     while(true){


### PR DESCRIPTION
"I suspect there have been recent changes in the CH55xDuino core that might have caused the library to fail to compile. By making this adjustment in the file, the library is operational once more."